### PR TITLE
Implement a forjj maintain --<plugin instance>-force true 

### DIFF
--- a/upstream/github/actions.go
+++ b/upstream/github/actions.go
@@ -241,6 +241,9 @@ func DoMaintain(w http.ResponseWriter, r *http.Request, req *MaintainReq, ret *g
 	if !gws.ensure_organization_exists(ret) {
 		return
 	}
+
+	gws.IsNewForge(req.Forj.Force)
+
 	if !gws.setOrganizationTeams(ret) {
 		return
 	}

--- a/upstream/github/actions.go
+++ b/upstream/github/actions.go
@@ -217,6 +217,7 @@ func DoMaintain(w http.ResponseWriter, r *http.Request, req *MaintainReq, ret *g
 			workspace_mount: req.Forj.ForjjWorkspaceMount,
 			token:           a.Token,
 			maintain_ctxt:   true,
+			force:           (req.Forj.Force == "true"),
 		}
 	}
 	check := make(map[string]bool)
@@ -242,7 +243,9 @@ func DoMaintain(w http.ResponseWriter, r *http.Request, req *MaintainReq, ret *g
 		return
 	}
 
-	gws.IsNewForge(req.Forj.Force)
+	if !gws.IsNewForge(ret) {
+		return
+	}
 
 	if !gws.setOrganizationTeams(ret) {
 		return

--- a/upstream/github/generated-yaml-structs.go
+++ b/upstream/github/generated-yaml-structs.go
@@ -112,6 +112,7 @@ type MaintainReq struct {
 		Debug string `json:"debug"`
 		ForjjInstanceName string `json:"forjj-instance-name"`
 		ForjjSourceMount string `json:"forjj-source-mount"`
+		Force string `json:"force"`
 		ForjjWorkspaceMount string `json:"forjj-workspace-mount"`
 	}
 	Objects MaintainArgReq
@@ -149,6 +150,8 @@ const YamlDesc = "---\n" +
    "  maintain:\n" +
    "    forjj-workspace-mount:\n" +
    "      help: \"Where the workspace dir is located in the github plugin container.\"\n" +
+   "    force:\n" +
+   "      help: Set 'true' to force removal of teams/users when forjj creates a new forge.\n" +
    "objects: # All objects will be delivered by forjj except workspace/infra under objects/<type>/<instance>/<action>/key=value\n" +
    "  # Define infra object special flag for github\n" +
    "  app: # already defined by Forjj\n" +

--- a/upstream/github/generated-yaml-structs.go
+++ b/upstream/github/generated-yaml-structs.go
@@ -67,11 +67,16 @@ type UserInstanceStruct struct {
 // Create request structure
 // ************************
 
-type CreateReq struct {
-	Forj struct {
+type ForjCommonStruct struct {
 		Debug string `json:"debug"`
 		ForjjInstanceName string `json:"forjj-instance-name"`
 		ForjjSourceMount string `json:"forjj-source-mount"`
+}
+
+type CreateReq struct {
+	Forj struct {
+		ForjCommonStruct
+		Force string `json:"force"`
 	}
 	Objects CreateArgReq
 }
@@ -89,9 +94,7 @@ type CreateArgReq struct {
 
 type UpdateReq struct {
 	Forj struct {
-		Debug string `json:"debug"`
-		ForjjInstanceName string `json:"forjj-instance-name"`
-		ForjjSourceMount string `json:"forjj-source-mount"`
+		ForjCommonStruct
 	}
 	Objects UpdateArgReq
 }
@@ -109,9 +112,7 @@ type UpdateArgReq struct {
 
 type MaintainReq struct {
 	Forj struct {
-		Debug string `json:"debug"`
-		ForjjInstanceName string `json:"forjj-instance-name"`
-		ForjjSourceMount string `json:"forjj-source-mount"`
+		ForjCommonStruct
 		Force string `json:"force"`
 		ForjjWorkspaceMount string `json:"forjj-workspace-mount"`
 	}
@@ -139,7 +140,7 @@ const YamlDesc = "---\n" +
    "  service:\n" +
    "    parameters: [ \"service\", \"start\" ]\n" +
    "created_flag_file: \"{{ .InstanceName }}/{{.Name}}.yaml\"\n" +
-   "task_flags: # All task flags will be delivered by forjj to the plugin under forj/\n" +
+   "task_flags: # Additional forjj task flags delivered by forjj to the plugin in req.Forj. Those flags are provided only through CLI.\n" +
    "  common:\n" +
    "    debug:\n" +
    "      help: \"To activate github debug information\"\n" +
@@ -147,6 +148,9 @@ const YamlDesc = "---\n" +
    "      help: \"Where the source dir is located for github plugin container.\"\n" +
    "    forjj-instance-name:\n" +
    "       help: \"Name of the jenkins instance given by forjj.\"\n" +
+   "  create:\n" +
+   "    force:\n" +
+   "      help: Set 'true' to force removal of teams/users when forjj creates a new forge.\n" +
    "  maintain:\n" +
    "    forjj-workspace-mount:\n" +
    "      help: \"Where the workspace dir is located in the github plugin container.\"\n" +
@@ -179,7 +183,6 @@ const YamlDesc = "---\n" +
    "        help: \"true if the plugin should not manage github users and groups\"\n" +
    "      repos_disabled:\n" +
    "        help: \"true if the plugin should not manage github repositories except the infra repository.\"\n" +
-   "\n" +
    "  # Define github group exposure to forjj\n" +
    "  group: # New object type in forjj\n" +
    "    # Default is : actions: [\"add\", \"change\", \"remove\", \"list\", \"rename\"]\n" +

--- a/upstream/github/github.yaml
+++ b/upstream/github/github.yaml
@@ -9,7 +9,7 @@ runtime:
   service:
     parameters: [ "service", "start" ]
 created_flag_file: "{{ .InstanceName }}/{{.Name}}.yaml"
-task_flags: # All task flags will be delivered by forjj to the plugin under forj/
+task_flags: # Additional forjj task flags delivered by forjj to the plugin in req.Forj. Those flags are provided only through CLI.
   common:
     debug:
       help: "To activate github debug information"
@@ -17,6 +17,9 @@ task_flags: # All task flags will be delivered by forjj to the plugin under forj
       help: "Where the source dir is located for github plugin container."
     forjj-instance-name:
        help: "Name of the jenkins instance given by forjj."
+  create:
+    force:
+      help: Set 'true' to force removal of teams/users when forjj creates a new forge.
   maintain:
     forjj-workspace-mount:
       help: "Where the workspace dir is located in the github plugin container."
@@ -49,7 +52,6 @@ objects: # All objects will be delivered by forjj except workspace/infra under o
         help: "true if the plugin should not manage github users and groups"
       repos_disabled:
         help: "true if the plugin should not manage github repositories except the infra repository."
-
   # Define github group exposure to forjj
   group: # New object type in forjj
     # Default is : actions: ["add", "change", "remove", "list", "rename"]

--- a/upstream/github/github.yaml
+++ b/upstream/github/github.yaml
@@ -17,9 +17,6 @@ task_flags: # Additional forjj task flags delivered by forjj to the plugin in re
       help: "Where the source dir is located for github plugin container."
     forjj-instance-name:
        help: "Name of the jenkins instance given by forjj."
-  create:
-    force:
-      help: Set 'true' to force removal of teams/users when forjj creates a new forge.
   maintain:
     forjj-workspace-mount:
       help: "Where the workspace dir is located in the github plugin container."

--- a/upstream/github/github.yaml
+++ b/upstream/github/github.yaml
@@ -20,6 +20,8 @@ task_flags: # All task flags will be delivered by forjj to the plugin under forj
   maintain:
     forjj-workspace-mount:
       help: "Where the workspace dir is located in the github plugin container."
+    force:
+      help: Set 'true' to force removal of teams/users when forjj creates a new forge.
 objects: # All objects will be delivered by forjj except workspace/infra under objects/<type>/<instance>/<action>/key=value
   # Define infra object special flag for github
   app: # already defined by Forjj

--- a/upstream/github/github_plugin.go
+++ b/upstream/github/github_plugin.go
@@ -17,6 +17,8 @@ type GitHubStruct struct {
 	github_source   GitHubSourceStruct // github source structure (yaml)
 	app             *AppInstanceStruct // Application information given by Forjj
 	maintain_ctxt   bool
+	new_forge       bool
+	force           bool
 }
 
 type GitHubSourceStruct struct {

--- a/upstream/github/github_plugin.go
+++ b/upstream/github/github_plugin.go
@@ -15,7 +15,8 @@ type GitHubStruct struct {
 	ctxt            context.Context
 	Client          *github.Client
 	github_source   GitHubSourceStruct // github source structure (yaml)
-	app             *AppInstanceStruct // Application information given by Forjj
+	app             *AppInstanceStruct // Application information given by Forjj at Create/Update phase
+	infra_repo      string
 	maintain_ctxt   bool
 	new_forge       bool
 	force           bool

--- a/upstream/github/glide.lock
+++ b/upstream/github/glide.lock
@@ -1,8 +1,8 @@
 hash: 44fd447fa628a8dba044dfc103da968a20199bba4197def8585581373da55b5c
-updated: 2017-07-19T16:06:53.312833041Z
+updated: 2017-09-30T20:33:58.352063933Z
 imports:
 - name: github.com/alecthomas/kingpin
-  version: 7f0871f2e17818990e4eed73f9b5c2f429501228
+  version: 1087e65c9441605df944fb12c33f0fe7072d18ca
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
   subpackages:
@@ -10,19 +10,19 @@ imports:
 - name: github.com/alecthomas/units
   version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
 - name: github.com/fatih/color
-  version: 62e9147c64a1ed519147b62a56a14e83e2be02c1
+  version: 5df930a27be2502f99b292b7cc09ebad4d0891f4
 - name: github.com/forj-oss/forjj-modules
-  version: 14e1fe07a3261ed4edd1204f59d63097e2b28e9a
+  version: 8b8218d066b0366c84393e205fefcb04ee74f291
   subpackages:
   - trace
 - name: github.com/forj-oss/goforjj
-  version: 34dcc12d0fefbf7a577809496ca77ec6475c5cc1
+  version: 02daa4dcfc2df6c822731d2bf39d0902e2f25615
 - name: github.com/golang/protobuf
-  version: 0a4f71a498b7c4812f64969510bcb4eca251e33a
+  version: 130e6b02ab059e7b717a096f397c5b60111cae74
   subpackages:
   - proto
 - name: github.com/google/go-github
-  version: d4206f97f4cbd4c357e2b825c886ad7bcacc184c
+  version: 511f540f1887d30b88cee4a2fcd1f2922754acf4
   subpackages:
   - github
 - name: github.com/google/go-querystring
@@ -32,7 +32,7 @@ imports:
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
-  version: bcd8bc72b08df0f70df986b97f95590779502d31
+  version: 24fca303ac6da784b9e8269f724ddeb0b2eea5e7
 - name: github.com/mattn/go-colorable
   version: 5411d3eea5978e6cdc258b30de592b60df6aba96
   repo: https://github.com/mattn/go-colorable
@@ -40,39 +40,37 @@ imports:
   version: 57fdcb988a5c543893cc61bce354a6e24ab70022
   repo: https://github.com/mattn/go-isatty
 - name: github.com/moul/http2curl
-  version: 4e24498b31dba4683efb9d35c1c8a91e2eda28c8
+  version: 9ac6cf4d929b2fa8fd2d2e6dec5bb0feb4f4911d
 - name: github.com/parnurzeal/gorequest
   version: a578a48e8d6ca8b01a3b18314c43c6716bb5f5a3
 - name: github.com/pkg/errors
-  version: c605e284fe17294bda444b34710735b29d1a9d90
+  version: 2b3a18b5f0fb6b4f9190549597d3f962c02bc5eb
 - name: golang.org/x/net
-  version: 02ac38e2528ff4adea90f184d71a3faa04b4b1b0
+  version: 0a9397675ba34b2845f758fe3cd68828369c6517
   subpackages:
   - context
   - context/ctxhttp
   - publicsuffix
 - name: golang.org/x/oauth2
-  version: cce311a261e6fcf29de72ca96827bdb0b7d9c9e6
+  version: bb50c06baba3d0c76f9d125c0719093e315b5b44
   subpackages:
   - internal
 - name: golang.org/x/sys
-  version: cd2c276457edda6df7fb04895d3fd6a6add42926
+  version: 314a259e304ff91bd6985da2a7149bbf91237993
   subpackages:
   - unix
 - name: google.golang.org/appengine
-  version: ad2570cd3913654e00c5f0183b39d2f998e54046
+  version: 24e4144ec923c2374f6b06610c0df16a9222c3d9
   subpackages:
   - internal
-  - internal/app_identity
   - internal/base
   - internal/datastore
   - internal/log
-  - internal/modules
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
 - name: gopkg.in/alecthomas/kingpin.v2
-  version: 7f0871f2e17818990e4eed73f9b5c2f429501228
+  version: 1087e65c9441605df944fb12c33f0fe7072d18ca
 - name: gopkg.in/yaml.v2
-  version: 3b4ad1db5b2a649883ff3782f5f9f6fb52be71af
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 testImports: []


### PR DESCRIPTION
If a team exist in github, but not in Forjfile, forjj will require to **forcelly** maintain the forge if the forge is **new**.
if not forced, forjj will simply abort maintain it and the forge won't be created.

A forge is new if the infra repository doesn't exist in the organization.

This PR will fix partially #102 
